### PR TITLE
set global constant default_warn_order to 32

### DIFF
--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -3,7 +3,7 @@
 # Warn about the order of the ITensor after contractions
 #
 
-const default_warn_order = 14
+const default_warn_order = 32
 
 const warn_order = Ref{Union{Int,Nothing}}(default_warn_order)
 


### PR DESCRIPTION
Set the default `default_warn_order` to 32. Otherwise the warning is too many in a rank tensor network contraction algorithm.